### PR TITLE
OTA/WS Stability Guards

### DIFF
--- a/lib/OTA/src/common.cpp
+++ b/lib/OTA/src/common.cpp
@@ -30,8 +30,15 @@ String get_redirect_location(WiFiClientSecure &wifi_client, String &initial_url)
     const char *TAG = "get_redirect_location";
     ESP_LOGV(TAG, "initial_url: %s\n", initial_url.c_str());
 
+    // Safety check: Limit URL length to prevent buffer overflows
+    if (initial_url.length() > 512) {
+        ESP_LOGE(TAG, "URL too long: %d chars (max 512)", initial_url.length());
+        return "";
+    }
+
     HTTPClient https;
     https.setFollowRedirects(HTTPC_DISABLE_FOLLOW_REDIRECTS);
+    https.setTimeout(10000);  // 10 second timeout to prevent hangs
 
     if (!https.begin(wifi_client, initial_url)) {
         ESP_LOGE(TAG, "[HTTPS] Unable to connect\n");
@@ -47,6 +54,13 @@ String get_redirect_location(WiFiClientSecure &wifi_client, String &initial_url)
     }
 
     String redirect_url = https.getLocation();
+    
+    // Safety check: Limit redirect URL length
+    if (redirect_url.length() > 512) {
+        ESP_LOGE(TAG, "Redirect URL too long: %d chars (max 512)", redirect_url.length());
+        redirect_url = "";
+    }
+    
     https.end();
 
     ESP_LOGI(TAG, "returns: %s\n", redirect_url.c_str());
@@ -55,8 +69,16 @@ String get_redirect_location(WiFiClientSecure &wifi_client, String &initial_url)
 
 String get_updated_version_via_txt_file(WiFiClientSecure &wifi_client, String &_release_url) {
     const char *TAG = "get_updated_version_via_txt_file";
+    
+    // Safety check: Limit URL length
+    if (_release_url.length() > 512) {
+        ESP_LOGE(TAG, "Release URL too long: %d chars (max 512)", _release_url.length());
+        return "";
+    }
+    
     HTTPClient https;
     https.setFollowRedirects(HTTPC_STRICT_FOLLOW_REDIRECTS);
+    https.setTimeout(10000);  // 10 second timeout
 
     String url = _release_url + "version.txt";
     ESP_LOGI(TAG, "url: %s\n", url.c_str());
@@ -73,6 +95,13 @@ String get_updated_version_via_txt_file(WiFiClientSecure &wifi_client, String &_
         ESP_LOGV(TAG, "httpCode: %d, errorCode %d: %s\n", httpCode, errCode, errorText);
     }
     String version = https.getString();
+    
+    // Safety check: Limit version string length
+    if (version.length() > 64) {
+        ESP_LOGE(TAG, "Version string too long: %d chars (max 64)", version.length());
+        version = "";
+    }
+    
     https.end();
     ESP_LOGI(TAG, "returns: %s\n", version.c_str());
     return version;

--- a/lib/OTA/src/semver_extensions.cpp
+++ b/lib/OTA/src/semver_extensions.cpp
@@ -34,8 +34,11 @@ semver_t from_string(const string &version) {
     if (split_at != string::npos) {
         patch = atoi(numbers.at(2).substr(0, split_at).c_str());
         auto prerelease = numbers.at(2).substr(split_at + 1);
-        prerelease_ptr = (char *)malloc(prerelease.length());
-        prerelease.copy(prerelease_ptr, prerelease.length());
+        prerelease_ptr = (char *)malloc(prerelease.length() + 1);  // +1 for null terminator
+        if (prerelease_ptr != nullptr) {
+            prerelease.copy(prerelease_ptr, prerelease.length());
+            prerelease_ptr[prerelease.length()] = '\0';  // Null terminate
+        }
     } else {
         patch = atoi(numbers.at(2).c_str());
     }

--- a/src/display/plugins/WebUIPlugin.cpp
+++ b/src/display/plugins/WebUIPlugin.cpp
@@ -211,8 +211,13 @@ void WebUIPlugin::handleWebSocketData(AsyncWebSocket *server, AsyncWebSocketClie
     if (info->index == 0) {
         auto &buf = rxBuffers[cid];
         buf.clear();
-        if (info->len <= 64 * 1024) {
+        const size_t MAX_WS_MESSAGE_SIZE = 128 * 1024;  // 128KB max
+        if (info->len <= MAX_WS_MESSAGE_SIZE) {
             buf.reserve(info->len);
+        } else {
+            ESP_LOGE("WebUIPlugin", "WebSocket message too large: %zu bytes (max %zu)", info->len, MAX_WS_MESSAGE_SIZE);
+            client->close(1009, "Message too large");
+            return;
         }
     }
 


### PR DESCRIPTION
"Remove VLAs
Add null pointer checks
Limit buffer sizes

Suggest reducing automatic OTA update check frequency to once per week - update can be checked on webui ota save/refresh anyways."